### PR TITLE
feat: add Braintree native SDK bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
-## 0.0.1
+## 0.1.0
 
-* TODO: Describe initial release.
+- Primeira versão funcional do plugin.
+- Suporte à tokenização de cartões de crédito.
+- Execução de verificação 3‑D Secure 2 nativa.
+- Coleta de *device data* para prevenção de fraudes.
+- Exemplos, testes unitários e documentação básica.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,62 @@
 # braintree_native_ui
 
-A new Flutter plugin project.
+Plugin Flutter que integra o SDK oficial da Braintree para permitir a
+implementação de fluxos de pagamento com UI própria. Ele tokeniza cartões,
+executa verificações 3‑D Secure (3DS2) e coleta *device data* para prevenção
+contra fraudes sem utilizar o componente Drop-in.
 
-## Getting Started
+## Recursos
 
-This project is a starting point for a Flutter
-[plug-in package](https://flutter.dev/to/develop-plugins),
-a specialized package that includes platform-specific implementation code for
-Android and/or iOS.
+- Tokenização de cartão de crédito
+- Verificação 3‑D Secure 2
+- Coleta de dados do dispositivo
+- API simples em Dart utilizando *Method Channels*
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+## Instalação
 
+Adicione ao seu `pubspec.yaml`:
+
+```yaml
+dependencies:
+  braintree_native_ui: ^0.1.0
+```
+
+No iOS execute `pod install` após atualizar as dependências.
+
+## Uso
+
+```dart
+final braintree = BraintreeNativeUi();
+
+final nonce = await braintree.tokenizeCard(
+  authorization: '<TOKENIZATION_KEY_OR_CLIENT_TOKEN>',
+  number: '4111111111111111',
+  expirationMonth: '12',
+  expirationYear: '2030',
+  cvv: '123',
+);
+
+final verifiedNonce = await braintree.performThreeDSecure(
+  authorization: '<TOKENIZATION_KEY_OR_CLIENT_TOKEN>',
+  nonce: nonce!,
+  amount: '10.00',
+);
+
+final deviceData = await braintree.collectDeviceData(
+  authorization: '<TOKENIZATION_KEY_OR_CLIENT_TOKEN>',
+);
+```
+
+Veja o diretório [`example/`](example) para um aplicativo completo.
+
+## Desenvolvimento
+
+Execute os testes com:
+
+```bash
+flutter test
+```
+
+## Licença
+
+Distribuído sob a licença MIT. Veja `LICENSE` para mais informações.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,6 +48,10 @@ android {
     }
 
     dependencies {
+        implementation("com.braintreepayments.api:card:5.14.0")
+        implementation("com.braintreepayments.api:three-d-secure:5.14.0")
+        implementation("com.braintreepayments.api:data-collector:5.14.0")
+
         testImplementation("org.jetbrains.kotlin:kotlin-test")
         testImplementation("org.mockito:mockito-core:5.0.0")
     }

--- a/android/src/main/kotlin/com/nagazakisoftware/braintree_native_ui/BraintreeNativeUiPlugin.kt
+++ b/android/src/main/kotlin/com/nagazakisoftware/braintree_native_ui/BraintreeNativeUiPlugin.kt
@@ -1,26 +1,136 @@
-package com.nagazakisoftware.braintree_custom_ui
+package com.nagazakisoftware.braintree_native_ui
 
+import android.app.Activity
+import android.content.Context
 import androidx.annotation.NonNull
+import com.braintreepayments.api.BraintreeClient
+import com.braintreepayments.api.Card
+import com.braintreepayments.api.CardClient
+import com.braintreepayments.api.DataCollector
+import com.braintreepayments.api.ThreeDSecureClient
+import com.braintreepayments.api.ThreeDSecureRequest
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 
-class BraintreeCustomUiPlugin: FlutterPlugin, MethodChannel.MethodCallHandler {
+/**
+ * Android implementation that bridges to the official Braintree SDK.
+ */
+class BraintreeNativeUiPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware {
   private lateinit var channel: MethodChannel
+  private lateinit var context: Context
+  private var activity: Activity? = null
 
   override fun onAttachedToEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
-    channel = MethodChannel(binding.binaryMessenger, "braintree_custom_ui")
+    context = binding.applicationContext
+    channel = MethodChannel(binding.binaryMessenger, "braintree_native_ui")
     channel.setMethodCallHandler(this)
-  }
-
-  override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
-    when (call.method) {
-      "ping" -> result.success("pong-android")
-      else -> result.notImplemented()
-    }
   }
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
     channel.setMethodCallHandler(null)
+  }
+
+  // ActivityAware
+  override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+    activity = binding.activity
+  }
+
+  override fun onDetachedFromActivity() {
+    activity = null
+  }
+
+  override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+    activity = binding.activity
+  }
+
+  override fun onDetachedFromActivityForConfigChanges() {
+    activity = null
+  }
+
+  override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+    when (call.method) {
+      "getPlatformVersion" -> result.success("Android ${android.os.Build.VERSION.RELEASE}")
+      "tokenizeCard" -> tokenize(call, result)
+      "performThreeDSecure" -> threeDSecure(call, result)
+      "collectDeviceData" -> collectDeviceData(call, result)
+      else -> result.notImplemented()
+    }
+  }
+
+  private fun tokenize(call: MethodCall, result: MethodChannel.Result) {
+    val authorization = call.argument<String>("authorization")
+    val number = call.argument<String>("number")
+    val expMonth = call.argument<String>("expirationMonth")
+    val expYear = call.argument<String>("expirationYear")
+    val cvv = call.argument<String>("cvv")
+
+    if (authorization == null || number == null || expMonth == null || expYear == null) {
+      result.error("arg_error", "Missing card parameters", null)
+      return
+    }
+
+    val btClient = BraintreeClient(activity ?: context, authorization)
+    val cardClient = CardClient(btClient)
+    val card = Card()
+    card.number = number
+    card.expirationMonth = expMonth
+    card.expirationYear = expYear
+    card.cvv = cvv
+
+    cardClient.tokenize(card) { cardNonce, error ->
+      if (error != null) {
+        result.error("tokenize_error", error.message, null)
+      } else {
+        result.success(cardNonce?.string)
+      }
+    }
+  }
+
+  private fun threeDSecure(call: MethodCall, result: MethodChannel.Result) {
+    val authorization = call.argument<String>("authorization")
+    val nonce = call.argument<String>("nonce")
+    val amount = call.argument<String>("amount")
+
+    val activity = activity
+    if (authorization == null || nonce == null || amount == null || activity == null) {
+      result.error("arg_error", "Missing parameters", null)
+      return
+    }
+
+    val btClient = BraintreeClient(activity, authorization)
+    val request = ThreeDSecureRequest()
+    request.nonce = nonce
+    request.amount = amount
+
+    val threeDSClient = ThreeDSecureClient(btClient)
+    threeDSClient.performVerification(activity, request) { threeDSResult, error ->
+      if (error != null) {
+        result.error("3ds_error", error.message, null)
+      } else {
+        result.success(threeDSResult?.tokenizedCard?.nonce)
+      }
+    }
+  }
+
+  private fun collectDeviceData(call: MethodCall, result: MethodChannel.Result) {
+    val authorization = call.argument<String>("authorization")
+    val activity = activity
+    if (authorization == null || activity == null) {
+      result.error("arg_error", "Missing parameters", null)
+      return
+    }
+
+    val btClient = BraintreeClient(activity, authorization)
+    val collector = DataCollector(btClient)
+    collector.collectDeviceData(activity) { deviceData, error ->
+      if (error != null) {
+        result.error("collector_error", error.message, null)
+      } else {
+        result.success(deviceData)
+      }
+    }
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,20 +1,72 @@
 import 'package:flutter/material.dart';
-import 'package:braintree_custom_ui/braintree_custom_ui.dart';
+import 'package:braintree_native_ui/braintree_native_ui.dart';
 
-void main() => runApp(const MyApp());
+void main() {
+  runApp(const MyApp());
+}
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
+
   @override
-  Widget build(BuildContext context) => MaterialApp(
-    home: Scaffold(
-      appBar: AppBar(title: const Text('Plugin example')),
-      body: Center(
-        child: FutureBuilder(
-          future: BraintreeCustomUi.ping(),
-          builder: (c, s) => Text('Ping: ${s.data ?? "..."}'),
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  final _braintree = BraintreeNativeUi();
+  String _output = '';
+
+  Future<void> _tokenizeCard() async {
+    try {
+      final nonce = await _braintree.tokenizeCard(
+        authorization: '<YOUR_TOKENIZATION_KEY>',
+        number: '4111111111111111',
+        expirationMonth: '12',
+        expirationYear: '2030',
+        cvv: '123',
+      );
+      setState(() => _output = 'Nonce: $nonce');
+    } catch (e) {
+      setState(() => _output = 'Error: $e');
+    }
+  }
+
+  Future<void> _collectDeviceData() async {
+    try {
+      final data = await _braintree.collectDeviceData(
+        authorization: '<YOUR_TOKENIZATION_KEY>',
+      );
+      setState(() => _output = 'Device data: $data');
+    } catch (e) {
+      setState(() => _output = 'Error: $e');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Braintree Native UI example')),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              ElevatedButton(
+                onPressed: _tokenizeCard,
+                child: const Text('Tokenize Card'),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: _collectDeviceData,
+                child: const Text('Collect Device Data'),
+              ),
+              const SizedBox(height: 16),
+              Text(_output),
+            ],
+          ),
         ),
       ),
-    ),
-  );
+    );
+  }
 }

--- a/ios/Classes/BraintreeNativeUiPlugin.swift
+++ b/ios/Classes/BraintreeNativeUiPlugin.swift
@@ -1,17 +1,108 @@
 import Flutter
 import UIKit
+import BraintreeCore
+import BraintreeCard
+import BraintreeThreeDSecure
+import BraintreeDataCollector
 
-public class BraintreeCustomUiPlugin: NSObject, FlutterPlugin {
+public class BraintreeNativeUiPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(name: "braintree_custom_ui", binaryMessenger: registrar.messenger())
-    let instance = BraintreeCustomUiPlugin()
+    let channel = FlutterMethodChannel(name: "braintree_native_ui", binaryMessenger: registrar.messenger())
+    let instance = BraintreeNativeUiPlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
-    case "ping": result("pong-ios")
-    default: result(FlutterMethodNotImplemented)
+    case "getPlatformVersion":
+      result("iOS " + UIDevice.current.systemVersion)
+    case "tokenizeCard":
+      tokenize(call: call, result: result)
+    case "performThreeDSecure":
+      threeDSecure(call: call, result: result)
+    case "collectDeviceData":
+      collectDeviceData(call: call, result: result)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func tokenize(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    guard
+      let args = call.arguments as? [String: Any],
+      let authorization = args["authorization"] as? String,
+      let number = args["number"] as? String,
+      let expMonth = args["expirationMonth"] as? String,
+      let expYear = args["expirationYear"] as? String
+    else {
+      result(FlutterError(code: "arg_error", message: "Missing card parameters", details: nil))
+      return
+    }
+    let cvv = args["cvv"] as? String
+
+    guard let apiClient = BTAPIClient(authorization: authorization) else {
+      result(FlutterError(code: "auth_error", message: "Invalid authorization", details: nil))
+      return
+    }
+    let cardClient = BTCardClient(apiClient: apiClient)
+    let card = BTCard(number: number, expirationMonth: expMonth, expirationYear: expYear, cvv: cvv)
+    cardClient.tokenize(card) { tokenizedCard, error in
+      if let error = error {
+        result(FlutterError(code: "tokenize_error", message: error.localizedDescription, details: nil))
+      } else {
+        result(tokenizedCard?.nonce)
+      }
+    }
+  }
+
+  private func threeDSecure(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    guard
+      let args = call.arguments as? [String: Any],
+      let authorization = args["authorization"] as? String,
+      let nonce = args["nonce"] as? String,
+      let amount = args["amount"] as? String,
+      let viewController = UIApplication.shared.keyWindow?.rootViewController
+    else {
+      result(FlutterError(code: "arg_error", message: "Missing parameters", details: nil))
+      return
+    }
+
+    guard let apiClient = BTAPIClient(authorization: authorization) else {
+      result(FlutterError(code: "auth_error", message: "Invalid authorization", details: nil))
+      return
+    }
+
+    let request = BTThreeDSecureRequest()
+    request.nonce = nonce
+    request.amount = NSDecimalNumber(string: amount)
+
+    let driver = BTThreeDSecureDriver(apiClient: apiClient, delegate: nil)
+    driver.verifyCard(with: request, viewController: viewController) { tokenizedCard, error in
+      if let error = error {
+        result(FlutterError(code: "3ds_error", message: error.localizedDescription, details: nil))
+      } else {
+        result(tokenizedCard?.nonce)
+      }
+    }
+  }
+
+  private func collectDeviceData(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    guard
+      let args = call.arguments as? [String: Any],
+      let authorization = args["authorization"] as? String
+    else {
+      result(FlutterError(code: "arg_error", message: "Missing authorization", details: nil))
+      return
+    }
+
+    guard let apiClient = BTAPIClient(authorization: authorization) else {
+      result(FlutterError(code: "auth_error", message: "Invalid authorization", details: nil))
+      return
+    }
+
+    let collector = BTDataCollector(apiClient: apiClient)
+    collector.collectDeviceData { deviceData, _ in
+      result(deviceData)
     }
   }
 }

--- a/ios/braintree_native_ui.podspec
+++ b/ios/braintree_native_ui.podspec
@@ -4,14 +4,15 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'braintree_native_ui'
-  s.version          = '0.0.1'
-  s.summary          = 'A new Flutter plugin project.'
+  s.version          = '0.1.0'
+  s.summary          = 'Braintree SDK integration with custom UI and 3DS2.'
   s.description      = <<-DESC
-A new Flutter plugin project.
+Tokenize cards, perform 3D Secure verification and collect device data using
+the official Braintree iOS SDK without relying on Drop-in UI.
                        DESC
-  s.homepage         = 'http://example.com'
+  s.homepage         = 'https://github.com/lucascelopes/braintree_native_ui'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
+  s.author           = { 'braintree_native_ui contributors' => 'support@example.com' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'

--- a/lib/braintree_native_ui.dart
+++ b/lib/braintree_native_ui.dart
@@ -1,8 +1,56 @@
 
 import 'braintree_native_ui_platform_interface.dart';
 
+/// Dart facade for the Braintree native SDKs.
+///
+/// Each method delegates to a platform implementation via
+/// [BraintreeNativeUiPlatform]. The native code is responsible for
+/// interacting with the official Braintree Android and iOS SDKs.
 class BraintreeNativeUi {
+  /// Returns the platform version reported by the host platform.
   Future<String?> getPlatformVersion() {
     return BraintreeNativeUiPlatform.instance.getPlatformVersion();
+  }
+
+  /// Tokenizes a credit card using the Braintree SDK and returns the
+  /// resulting payment method nonce.
+  ///
+  /// [authorization] is either a client token or tokenization key.
+  Future<String?> tokenizeCard({
+    required String authorization,
+    required String number,
+    required String expirationMonth,
+    required String expirationYear,
+    String? cvv,
+  }) {
+    return BraintreeNativeUiPlatform.instance.tokenizeCard(
+      authorization: authorization,
+      number: number,
+      expirationMonth: expirationMonth,
+      expirationYear: expirationYear,
+      cvv: cvv,
+    );
+  }
+
+  /// Performs a 3‑D Secure verification for the given [nonce] and [amount].
+  ///
+  /// Returns the verified nonce if the challenge succeeds.
+  Future<String?> performThreeDSecure({
+    required String authorization,
+    required String nonce,
+    required String amount,
+  }) {
+    return BraintreeNativeUiPlatform.instance.performThreeDSecure(
+      authorization: authorization,
+      nonce: nonce,
+      amount: amount,
+    );
+  }
+
+  /// Collects device data used for fraud protection.
+  Future<String?> collectDeviceData({required String authorization}) {
+    return BraintreeNativeUiPlatform.instance.collectDeviceData(
+      authorization: authorization,
+    );
   }
 }

--- a/lib/braintree_native_ui_method_channel.dart
+++ b/lib/braintree_native_ui_method_channel.dart
@@ -14,4 +14,48 @@ class MethodChannelBraintreeNativeUi extends BraintreeNativeUiPlatform {
     final version = await methodChannel.invokeMethod<String>('getPlatformVersion');
     return version;
   }
+
+  @override
+  Future<String?> tokenizeCard({
+    required String authorization,
+    required String number,
+    required String expirationMonth,
+    required String expirationYear,
+    String? cvv,
+  }) async {
+    final nonce = await methodChannel.invokeMethod<String>('tokenizeCard', {
+      'authorization': authorization,
+      'number': number,
+      'expirationMonth': expirationMonth,
+      'expirationYear': expirationYear,
+      'cvv': cvv,
+    });
+    return nonce;
+  }
+
+  @override
+  Future<String?> performThreeDSecure({
+    required String authorization,
+    required String nonce,
+    required String amount,
+  }) async {
+    final verifiedNonce =
+        await methodChannel.invokeMethod<String>('performThreeDSecure', {
+      'authorization': authorization,
+      'nonce': nonce,
+      'amount': amount,
+    });
+    return verifiedNonce;
+  }
+
+  @override
+  Future<String?> collectDeviceData({required String authorization}) async {
+    final deviceData = await methodChannel.invokeMethod<String>(
+      'collectDeviceData',
+      {
+        'authorization': authorization,
+      },
+    );
+    return deviceData;
+  }
 }

--- a/lib/braintree_native_ui_platform_interface.dart
+++ b/lib/braintree_native_ui_platform_interface.dart
@@ -26,4 +26,26 @@ abstract class BraintreeNativeUiPlatform extends PlatformInterface {
   Future<String?> getPlatformVersion() {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
+
+  Future<String?> tokenizeCard({
+    required String authorization,
+    required String number,
+    required String expirationMonth,
+    required String expirationYear,
+    String? cvv,
+  }) {
+    throw UnimplementedError('tokenizeCard() has not been implemented.');
+  }
+
+  Future<String?> performThreeDSecure({
+    required String authorization,
+    required String nonce,
+    required String amount,
+  }) {
+    throw UnimplementedError('performThreeDSecure() has not been implemented.');
+  }
+
+  Future<String?> collectDeviceData({required String authorization}) {
+    throw UnimplementedError('collectDeviceData() has not been implemented.');
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ flutter:
   plugin:
     platforms:
       android:
-        package: com.nagazakisoftware.braintree_custom_ui
-        pluginClass: BraintreeCustomUiPlugin
+        package: com.nagazakisoftware.braintree_native_ui
+        pluginClass: BraintreeNativeUiPlugin
       ios:
-        pluginClass: BraintreeCustomUiPlugin
+        pluginClass: BraintreeNativeUiPlugin

--- a/test/braintree_native_ui_method_channel_test.dart
+++ b/test/braintree_native_ui_method_channel_test.dart
@@ -12,7 +12,18 @@ void main() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
       channel,
       (MethodCall methodCall) async {
-        return '42';
+        switch (methodCall.method) {
+          case 'getPlatformVersion':
+            return '42';
+          case 'tokenizeCard':
+            return 'fake-nonce';
+          case 'performThreeDSecure':
+            return 'verified-nonce';
+          case 'collectDeviceData':
+            return 'device-data';
+          default:
+            return null;
+        }
       },
     );
   });
@@ -23,5 +34,29 @@ void main() {
 
   test('getPlatformVersion', () async {
     expect(await platform.getPlatformVersion(), '42');
+  });
+
+  test('tokenizeCard', () async {
+    final nonce = await platform.tokenizeCard(
+      authorization: 'auth',
+      number: '4111111111111111',
+      expirationMonth: '12',
+      expirationYear: '2030',
+    );
+    expect(nonce, 'fake-nonce');
+  });
+
+  test('performThreeDSecure', () async {
+    final verifiedNonce = await platform.performThreeDSecure(
+      authorization: 'auth',
+      nonce: 'fake-nonce',
+      amount: '10.00',
+    );
+    expect(verifiedNonce, 'verified-nonce');
+  });
+
+  test('collectDeviceData', () async {
+    final data = await platform.collectDeviceData(authorization: 'auth');
+    expect(data, 'device-data');
   });
 }

--- a/test/braintree_native_ui_test.dart
+++ b/test/braintree_native_ui_test.dart
@@ -10,6 +10,28 @@ class MockBraintreeNativeUiPlatform
 
   @override
   Future<String?> getPlatformVersion() => Future.value('42');
+
+  @override
+  Future<String?> tokenizeCard({
+    required String authorization,
+    required String number,
+    required String expirationMonth,
+    required String expirationYear,
+    String? cvv,
+  }) =>
+      Future.value('fake-nonce');
+
+  @override
+  Future<String?> performThreeDSecure({
+    required String authorization,
+    required String nonce,
+    required String amount,
+  }) =>
+      Future.value('verified-nonce');
+
+  @override
+  Future<String?> collectDeviceData({required String authorization}) =>
+      Future.value('device-data');
 }
 
 void main() {
@@ -25,5 +47,47 @@ void main() {
     BraintreeNativeUiPlatform.instance = fakePlatform;
 
     expect(await braintreeNativeUiPlugin.getPlatformVersion(), '42');
+  });
+
+  test('tokenizeCard delegates to platform', () async {
+    final plugin = BraintreeNativeUi();
+    final fakePlatform = MockBraintreeNativeUiPlatform();
+    BraintreeNativeUiPlatform.instance = fakePlatform;
+
+    expect(
+      await plugin.tokenizeCard(
+        authorization: 'auth',
+        number: '4111111111111111',
+        expirationMonth: '12',
+        expirationYear: '2030',
+      ),
+      'fake-nonce',
+    );
+  });
+
+  test('performThreeDSecure delegates to platform', () async {
+    final plugin = BraintreeNativeUi();
+    final fakePlatform = MockBraintreeNativeUiPlatform();
+    BraintreeNativeUiPlatform.instance = fakePlatform;
+
+    expect(
+      await plugin.performThreeDSecure(
+        authorization: 'auth',
+        nonce: 'fake-nonce',
+        amount: '10.00',
+      ),
+      'verified-nonce',
+    );
+  });
+
+  test('collectDeviceData delegates to platform', () async {
+    final plugin = BraintreeNativeUi();
+    final fakePlatform = MockBraintreeNativeUiPlatform();
+    BraintreeNativeUiPlatform.instance = fakePlatform;
+
+    expect(
+      await plugin.collectDeviceData(authorization: 'auth'),
+      'device-data',
+    );
   });
 }


### PR DESCRIPTION
## Summary
- add Dart API for card tokenization, 3DS2 verification and device data collection
- implement native Android and iOS bridges to Braintree SDK
- provide example app, tests and documentation

## Testing
- `flutter test` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689ce4c916e483318c50405bfaf88e1b