### PR TITLE
docs: expand README and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+- Adicionada dependência `plugin_platform_interface`.
+- Exemplos de uso com `TextField`.
+- Documentação inicial para Google Pay e Apple Pay.
+
 ## 0.1.0
 
 - Primeira versão funcional do plugin.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ contra fraudes sem utilizar o componente Drop-in.
 - Verificação 3‑D Secure 2
 - Coleta de dados do dispositivo
 - API simples em Dart utilizando *Method Channels*
+- Preparado para integração com Google Pay e Apple Pay
 
 ## Instalação
 
@@ -18,7 +19,7 @@ Adicione ao seu `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  braintree_native_ui: ^0.1.0
+  braintree_native_ui: ^0.1.1
 ```
 
 No iOS execute `pod install` após atualizar as dependências.
@@ -44,6 +45,52 @@ final verifiedNonce = await braintree.performThreeDSecure(
 
 final deviceData = await braintree.collectDeviceData(
   authorization: '<TOKENIZATION_KEY_OR_CLIENT_TOKEN>',
+);
+```
+
+### Capturando dados com TextFields
+
+```dart
+final numberController = TextEditingController();
+final expMonthController = TextEditingController();
+final expYearController = TextEditingController();
+final cvvController = TextEditingController();
+
+// Campos de entrada personalizados
+TextField(controller: numberController);
+TextField(controller: expMonthController);
+TextField(controller: expYearController);
+TextField(controller: cvvController);
+
+final nonce = await braintree.tokenizeCard(
+  authorization: '<TOKENIZATION_KEY_OR_CLIENT_TOKEN>',
+  number: numberController.text,
+  expirationMonth: expMonthController.text,
+  expirationYear: expYearController.text,
+  cvv: cvvController.text,
+);
+```
+
+## Google Pay
+
+Suporte a Google Pay está em desenvolvimento. A integração prevista será:
+
+```dart
+final googlePayNonce = await braintree.requestGooglePay(
+  authorization: '<TOKENIZATION_KEY_OR_CLIENT_TOKEN>',
+  amount: '10.00',
+);
+```
+
+## Apple Pay
+
+De forma similar, o Apple Pay terá uma API dedicada:
+
+```dart
+final applePayNonce = await braintree.requestApplePay(
+  authorization: '<TOKENIZATION_KEY_OR_CLIENT_TOKEN>',
+  merchantId: 'merchant.com.exemplo',
+  amount: '10.00',
 );
 ```
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.1.1"
   characters:
     dependency: transitive
     description:
@@ -280,4 +280,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.19.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: braintree_native_ui
 description: Plugin nativo para tokenizar cartão, rodar 3DS2 e coletar device data com Braintree usando UI própria.
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/lucascelopes/braintree_native_ui
 issue_tracker: https://github.com/lucascelopes/braintree_native_ui/issues
 homepage: https://github.com/lucascelopes/braintree_native_ui
@@ -13,6 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  plugin_platform_interface: ^2.1.8
 
 dev_dependencies:
   flutter_lints: ^4.0.0


### PR DESCRIPTION
## Summary
- document upcoming Google Pay and Apple Pay support
- add TextField usage example
- bump version to 0.1.1 and include plugin_platform_interface dependency

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_b_689ce7d735f08331bd51c34a3ef96b27