### PR TITLE
Improve payment flows and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,19 @@ final verifiedNonce = await braintree.performThreeDSecure(
   authorization: '<TOKENIZATION_KEY_OR_CLIENT_TOKEN>',
   nonce: nonce!,
   amount: '10.00',
+  email: 'user@example.com',
+  billingAddress: {
+    'streetAddress': 'Rua 1',
+    'locality': 'Sao Paulo',
+    'region': 'SP',
+    'postalCode': '01000-000',
+    'countryCodeAlpha2': 'BR',
+  },
 );
 
 final deviceData = await braintree.collectDeviceData(
   authorization: '<TOKENIZATION_KEY_OR_CLIENT_TOKEN>',
+  forCard: true,
 );
 ```
 
@@ -81,13 +90,10 @@ final googlePayNonce = await braintree.requestGooglePayPayment(
   authorization: '<TOKENIZATION_KEY_OR_CLIENT_TOKEN>',
   amount: '10.00',
   currencyCode: 'USD',
-Suporte a Google Pay está em desenvolvimento. A integração prevista será:
-```dart
-final googlePayNonce = await braintree.requestGooglePay(
-  authorization: '<TOKENIZATION_KEY_OR_CLIENT_TOKEN>',
-  amount: '10.00',
 );
 ```
+
+Configure o `gatewayMerchantId` e o ambiente (`TEST` ou `PRODUCTION`) conforme a documentação do Google Pay antes de enviar para produção.
 
 ## Apple Pay
 
@@ -99,15 +105,11 @@ final applePayNonce = await braintree.requestApplePayPayment(
   merchantIdentifier: 'merchant.com.exemplo',
   countryCode: 'US',
   currencyCode: 'USD',
-
-De forma similar, o Apple Pay terá uma API dedicada:
-```dart
-final applePayNonce = await braintree.requestApplePay(
-  authorization: '<TOKENIZATION_KEY_OR_CLIENT_TOKEN>',
-  merchantId: 'merchant.com.exemplo',
   amount: '10.00',
 );
 ```
+
+Certifique-se de registrar o `merchantIdentifier` e definir o ambiente apropriado (`sandbox` ou produção) no Apple Developer.
 
 Veja o diretório [`example/`](example) para um aplicativo completo.
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,6 +35,7 @@ class _MyAppState extends State<MyApp> {
     try {
       final data = await _braintree.collectDeviceData(
         authorization: '<YOUR_TOKENIZATION_KEY>',
+        forCard: true,
       );
       setState(() => _output = 'Device data: $data');
     } catch (e) {

--- a/lib/braintree_native_ui.dart
+++ b/lib/braintree_native_ui.dart
@@ -38,18 +38,26 @@ class BraintreeNativeUi {
     required String authorization,
     required String nonce,
     required String amount,
+    String? email,
+    Map<String, String>? billingAddress,
   }) {
     return BraintreeNativeUiPlatform.instance.performThreeDSecure(
       authorization: authorization,
       nonce: nonce,
       amount: amount,
+      email: email,
+      billingAddress: billingAddress,
     );
   }
 
   /// Collects device data used for fraud protection.
-  Future<String?> collectDeviceData({required String authorization}) {
+  Future<String?> collectDeviceData({
+    required String authorization,
+    bool forCard = false,
+  }) {
     return BraintreeNativeUiPlatform.instance.collectDeviceData(
       authorization: authorization,
+      forCard: forCard,
     );
   }
 

--- a/lib/braintree_native_ui_method_channel.dart
+++ b/lib/braintree_native_ui_method_channel.dart
@@ -40,19 +40,30 @@ class MethodChannelBraintreeNativeUi extends BraintreeNativeUiPlatform {
     required String authorization,
     required String nonce,
     required String amount,
+    String? email,
+    Map<String, String>? billingAddress,
   }) async {
     final verifiedNonce = await methodChannel.invokeMethod<String>(
       'performThreeDSecure',
-      {'authorization': authorization, 'nonce': nonce, 'amount': amount},
+      {
+        'authorization': authorization,
+        'nonce': nonce,
+        'amount': amount,
+        'email': email,
+        'billingAddress': billingAddress,
+      },
     );
     return verifiedNonce;
   }
 
   @override
-  Future<String?> collectDeviceData({required String authorization}) async {
+  Future<String?> collectDeviceData({
+    required String authorization,
+    bool forCard = false,
+  }) async {
     final deviceData = await methodChannel.invokeMethod<String>(
       'collectDeviceData',
-      {'authorization': authorization},
+      {'authorization': authorization, 'forCard': forCard},
     );
     return deviceData;
   }

--- a/lib/braintree_native_ui_platform_interface.dart
+++ b/lib/braintree_native_ui_platform_interface.dart
@@ -41,11 +41,16 @@ abstract class BraintreeNativeUiPlatform extends PlatformInterface {
     required String authorization,
     required String nonce,
     required String amount,
+    String? email,
+    Map<String, String>? billingAddress,
   }) {
     throw UnimplementedError('performThreeDSecure() has not been implemented.');
   }
 
-  Future<String?> collectDeviceData({required String authorization}) {
+  Future<String?> collectDeviceData({
+    required String authorization,
+    bool forCard = false,
+  }) {
     throw UnimplementedError('collectDeviceData() has not been implemented.');
   }
 

--- a/test/braintree_native_ui_test.dart
+++ b/test/braintree_native_ui_test.dart
@@ -24,10 +24,15 @@ class MockBraintreeNativeUiPlatform
     required String authorization,
     required String nonce,
     required String amount,
+    String? email,
+    Map<String, String>? billingAddress,
   }) => Future.value('verified-nonce');
 
   @override
-  Future<String?> collectDeviceData({required String authorization}) =>
+  Future<String?> collectDeviceData({
+    required String authorization,
+    bool forCard = false,
+  }) =>
       Future.value('device-data');
 
   @override


### PR DESCRIPTION
## Summary
- Replace deprecated keyWindow lookups with scene-aware root view controller and enhance Apple Pay delegate with cancel/error handling
- Extend 3‑D Secure requests with email and billing address fields and support card-specific device data collection
- Clean up Google Pay and Apple Pay docs with configuration notes and examples

## Testing
- ❌ `flutter test` (command not found)
- ❌ `dart test` (command not found)


------
https://chatgpt.com/codex/tasks/task_b_689cef6e44c883318d551620245204ca