### PR TITLE
feat: conditional Braintree imports and podspec linting

### DIFF
--- a/.github/workflows/flutterpluginci.yml
+++ b/.github/workflows/flutterpluginci.yml
@@ -68,3 +68,13 @@ jobs:
       # Útil para garantir que o package passa nas checagens de publicação
       - name: Dry-run de publicação no Pub
         run: dart pub publish --dry-run
+
+  lint_podspec:
+    name: Lint Podspec (macOS)
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate podspec
+        run: pod lib lint ios/braintree_native_ui.podspec --allow-warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+- Ajuste de imports condicionais para compatibilidade com CocoaPods e SPM.
+- Adicionada validação do Podspec na pipeline de CI.
+
 ## 0.2.1
 - Correções IOS 13+.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.2.2"
   characters:
     dependency: transitive
     description:
@@ -109,26 +109,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.1"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -250,18 +250,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/ios/Classes/BraintreeNativeUiPlugin.swift
+++ b/ios/Classes/BraintreeNativeUiPlugin.swift
@@ -2,9 +2,25 @@ import Flutter
 import UIKit
 #if canImport(BraintreeCore)
 import BraintreeCore
+#else
+import Braintree
+#endif
+#if canImport(BraintreeCard)
 import BraintreeCard
+#else
+import Braintree
+#endif
+#if canImport(BraintreeThreeDSecure)
 import BraintreeThreeDSecure
+#else
+import Braintree
+#endif
+#if canImport(BraintreeDataCollector)
 import BraintreeDataCollector
+#else
+import Braintree
+#endif
+#if canImport(BraintreeApplePay)
 import BraintreeApplePay
 #else
 import Braintree

--- a/ios/braintree_native_ui.podspec
+++ b/ios/braintree_native_ui.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'braintree_native_ui'
-  s.version          = '0.2.1'
+  s.version          = '0.2.2'
   s.summary          = 'Braintree SDK integration with custom UI and 3DS2.'
   s.description      = <<-DESC
 Tokenize cards, perform 3D Secure verification and collect device data using

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: braintree_native_ui
 description: Plugin nativo para tokenizar cartão, rodar 3DS2 e coletar device data com Braintree usando UI própria.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/lucascelopes/braintree_native_ui
 issue_tracker: https://github.com/lucascelopes/braintree_native_ui/issues
 homepage: https://github.com/lucascelopes/braintree_native_ui


### PR DESCRIPTION
## Summary
- support CocoaPods by conditionally importing Braintree umbrella module
- bump package to 0.2.2 and update podspec
- lint podspec in CI workflow

## Testing
- `flutter analyze --fatal-infos --fatal-warnings`
- `flutter test`
- `dart pub publish --dry-run`


------
https://chatgpt.com/codex/tasks/task_b_689e46ab057c833181b976ec62d03bd4