### PR TITLE
Update Braintree initialization for v7

### DIFF
--- a/ios/Classes/BraintreeNativeUiPlugin.swift
+++ b/ios/Classes/BraintreeNativeUiPlugin.swift
@@ -89,13 +89,7 @@ public class BraintreeNativeUiPlugin: NSObject, FlutterPlugin {
       return
     }
     let cvv = args["cvv"] as? String
-
-    guard let apiClient = BTAPIClient(authorization: authorization) else {
-      result(asFlutterError("auth_error", -2, "Invalid authorization"))
-      return
-    }
-
-    let cardClient = BTCardClient(apiClient: apiClient)
+    let cardClient = BTCardClient(authorization: authorization)
     let card = BTCard(number: number, expirationMonth: expMonth, expirationYear: expYear, cvv: cvv)
 
     // v6: assinatura correta é tokenize(_ card: BTCard, completion: ...)
@@ -124,13 +118,7 @@ public class BraintreeNativeUiPlugin: NSObject, FlutterPlugin {
       result(asFlutterError("arg_error", -1, "Missing parameters"))
       return
     }
-
-    guard let apiClient = BTAPIClient(authorization: authorization) else {
-      result(asFlutterError("auth_error", -2, "Invalid authorization"))
-      return
-    }
-
-    let threeDSecureClient = BTThreeDSecureClient(apiClient: apiClient)
+    let threeDSecureClient = BTThreeDSecureClient(authorization: authorization)
     let request = BTThreeDSecureRequest()
     request.nonce = nonce
     request.amount = NSDecimalNumber(string: amount)
@@ -179,12 +167,7 @@ public class BraintreeNativeUiPlugin: NSObject, FlutterPlugin {
       return
     }
 
-    guard let apiClient = BTAPIClient(authorization: authorization) else {
-      result(asFlutterError("auth_error", -2, "Invalid authorization"))
-      return
-    }
-
-    let collector = BTDataCollector(apiClient: apiClient)
+    let collector = BTDataCollector(authorization: authorization)
     collector.collectDeviceData { deviceData, error in
       if let error = error as NSError? {
         result(self.asFlutterError("data_error", error.code, error.localizedDescription))
@@ -211,13 +194,7 @@ public class BraintreeNativeUiPlugin: NSObject, FlutterPlugin {
       result(asFlutterError("arg_error", -1, "Missing parameters"))
       return
     }
-
-    guard let apiClient = BTAPIClient(authorization: authorization) else {
-      result(asFlutterError("auth_error", -2, "Invalid authorization"))
-      return
-    }
-
-    let applePayClient = BTApplePayClient(apiClient: apiClient)
+    let applePayClient = BTApplePayClient(authorization: authorization)
     let paymentRequest = PKPaymentRequest()
     paymentRequest.merchantIdentifier = merchantId
     paymentRequest.countryCode = countryCode

--- a/ios/braintree_native_ui.podspec
+++ b/ios/braintree_native_ui.podspec
@@ -20,11 +20,11 @@ the official Braintree iOS SDK without relying on Drop-in UI.
   s.platform         = :ios, '14.0'
   s.swift_version    = '5.0'
 
-  s.dependency 'Braintree/Core',          '~> 6.36'
-  s.dependency 'Braintree/Card',          '~> 6.36'
-  s.dependency 'Braintree/ThreeDSecure',  '~> 6.36'
-  s.dependency 'Braintree/DataCollector', '~> 6.36'
-  s.dependency 'Braintree/ApplePay',      '~> 6.36'
+  s.dependency 'Braintree/Core',          '~> 7.0'
+  s.dependency 'Braintree/Card',          '~> 7.0'
+  s.dependency 'Braintree/ThreeDSecure',  '~> 7.0'
+  s.dependency 'Braintree/DataCollector', '~> 7.0'
+  s.dependency 'Braintree/ApplePay',      '~> 7.0'
 
   s.static_framework = true
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }


### PR DESCRIPTION
## Summary
- migrate plugin to authorization-based Braintree v7 APIs
- bump CocoaPods dependencies to Braintree 7.x

## Testing
- `flutter analyze` *(command not found)*
- `dart test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f6bf695008331bdcbd63297afae76