### PR TITLE
chore: bump to 0.4.0 and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.4.0] - 2025-08-16
+### Corrigido
+- Correções técnicas e melhorias gerais.
+
 ## [0.3.7] - 2025-08-15
 ### Alterado
 - Atualizado código Swift para compatibilidade total com **Braintree iOS SDK v6.36**.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Adicione ao seu `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  braintree_native_ui: ^0.2.0
+  braintree_native_ui: ^0.4.0
 ```
 
 No iOS execute `pod install` após atualizar as dependências.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.4.0"
   characters:
     dependency: transitive
     description:

--- a/ios/braintree_native_ui.podspec
+++ b/ios/braintree_native_ui.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'braintree_native_ui'
-  s.version          = '0.3.10'
+  s.version          = '0.4.0'
   s.summary          = 'Braintree SDK integration with custom UI and 3DS2.'
   s.description      = <<-DESC
 Tokenize cards, perform 3D Secure verification and collect device data using

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: braintree_native_ui
 description: Plugin nativo para tokenizar cartão, rodar 3DS2 e coletar device data com Braintree usando UI própria.
-version: 0.3.10
+version: 0.4.0
 repository: https://github.com/lucascelopes/braintree_native_ui
 issue_tracker: https://github.com/lucascelopes/braintree_native_ui/issues
 homepage: https://github.com/lucascelopes/braintree_native_ui


### PR DESCRIPTION
## Summary
- document technical fixes for v0.4.0
- bump package and podspec versions to 0.4.0
- update README and example lockfile

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0b0e6d44c833180cb9ec480def9fd